### PR TITLE
Fix/sub menu render

### DIFF
--- a/src/components/DropDownItems.vue
+++ b/src/components/DropDownItems.vue
@@ -1,8 +1,11 @@
 <template>
   <div :class="{'dropdown-menu': depth === 0}" :aria-labelledby="parent.id">
     <template v-for="item in items">
-      <a :key="item.id" v-if="item.type === 'plugin'" class="dropdown-item"
-         :href="`/menu/${parent.id}/${href(item)}`">
+      <a v-if="item.type === 'plugin'"
+         class="dropdown-item"
+         :key="item.id"
+         :href="`/menu/${parent.id}/${href(item)}`"
+         :class="'menu-depth-'+ depth">
         {{ item.label }}
       </a>
 
@@ -42,3 +45,25 @@ export default Vue.extend({
   }
 })
 </script>
+
+<style>
+  .menu-depth-1 {
+    padding-left: 2rem;
+  }
+
+  .menu-depth-2 {
+    padding-left: 3rem;
+  }
+
+  .menu-depth-3 {
+    padding-left: 4rem;
+  }
+
+  .menu-depth-4 {
+    padding-left: 5rem;
+  }
+
+  .menu-depth-5 {
+    padding-left: 6rem;
+  }
+</style>

--- a/src/exampleMenu.ts
+++ b/src/exampleMenu.ts
@@ -40,49 +40,49 @@ const molgenisMenu: MolgenisMenu = {
         params: 'selectedEntityType=sys_md_EntityType'
       },
       {
-        type: "menu",
-        id: "dataintegration",
-        label: "Data Integration",
+        type: 'menu',
+        id: 'dataintegration',
+        label: 'Data Integration',
         items: [
           {
-            type: "plugin",
-            id: "metadata-manager",
-            label: "Metadata Manager"
+            type: 'plugin',
+            id: 'metadata-manager',
+            label: 'Metadata Manager'
           },
           {
-            type: "menu",
-            id: "submenu",
-            label: "Submenu",
+            type: 'menu',
+            id: 'submenu',
+            label: 'Submenu',
             items: [
               {
-                type: "plugin",
-                id: "sorta",
-                label: "SORTA"
+                type: 'plugin',
+                id: 'sorta',
+                label: 'SORTA'
               },
               {
-                type: "menu",
-                id: "subsubmenu",
-                label: "Sub Sub Menu",
+                type: 'menu',
+                id: 'subsubmenu',
+                label: 'Sub Sub Menu',
                 items: [
                   {
-                    type: "plugin",
-                    id: "background",
-                    label: "Test",
-                    "params": ""
+                    type: 'plugin',
+                    id: 'background',
+                    label: 'Test',
+                    'params': ''
                   }
                 ]
               },
               {
-                type: "plugin",
-                id: "mappingservice",
-                label: "Mapping Service"
+                type: 'plugin',
+                id: 'mappingservice',
+                label: 'Mapping Service'
               }
             ]
           },
           {
-            type: "plugin",
-            id: "tagwizard",
-            label: "Tag Wizard"
+            type: 'plugin',
+            id: 'tagwizard',
+            label: 'Tag Wizard'
           }
         ]
       },

--- a/src/exampleMenu.ts
+++ b/src/exampleMenu.ts
@@ -40,29 +40,49 @@ const molgenisMenu: MolgenisMenu = {
         params: 'selectedEntityType=sys_md_EntityType'
       },
       {
-        type: 'menu',
-        id: 'dataintegration',
-        label: 'Data Integration',
+        type: "menu",
+        id: "dataintegration",
+        label: "Data Integration",
         items: [
           {
-            type: 'plugin',
-            id: 'metadata-manager',
-            label: 'Metadata Manager'
+            type: "plugin",
+            id: "metadata-manager",
+            label: "Metadata Manager"
           },
           {
-            type: 'plugin',
-            id: 'mappingservice',
-            label: 'Mapping Service'
+            type: "menu",
+            id: "submenu",
+            label: "Submenu",
+            items: [
+              {
+                type: "plugin",
+                id: "sorta",
+                label: "SORTA"
+              },
+              {
+                type: "menu",
+                id: "subsubmenu",
+                label: "Sub Sub Menu",
+                items: [
+                  {
+                    type: "plugin",
+                    id: "background",
+                    label: "Test",
+                    "params": ""
+                  }
+                ]
+              },
+              {
+                type: "plugin",
+                id: "mappingservice",
+                label: "Mapping Service"
+              }
+            ]
           },
           {
-            type: 'plugin',
-            id: 'sorta',
-            label: 'SORTA'
-          },
-          {
-            type: 'plugin',
-            id: 'tagwizard',
-            label: 'Tag Wizard'
+            type: "plugin",
+            id: "tagwizard",
+            label: "Tag Wizard"
           }
         ]
       },

--- a/tests/unit/__snapshots__/NavBar.spec.ts.snap
+++ b/tests/unit/__snapshots__/NavBar.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`NavBar.vue should match the snapshot 1`] = `
       <li class="nav-item dropdown"><a id="dataintegration" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="nav-link dropdown-toggle">
           Data Integration
         </a>
-        <drop-down-items-stub parent="[object Object]" items="[object Object],[object Object],[object Object],[object Object]" depth="0"></drop-down-items-stub>
+        <drop-down-items-stub parent="[object Object]" items="[object Object],[object Object],[object Object]" depth="0"></drop-down-items-stub>
       </li>
       <li class="nav-item dropdown"><a id="plugins" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="nav-link dropdown-toggle">
           Plugins


### PR DESCRIPTION
Fix #22 

Molgenis issue: [Menu entries incorrectly displayed in submenu for plugins using Vue header #6728](https://github.com/molgenis/molgenis/issues/6728)

Style submenus  …
- Add class indicating menu depth.
- Add default styles for levels 1 to 5.

Explored a alternative version using js to change the style prop attribute using vue, but i prefer this solution ( using js to generate classes, and styling the classes) as it better allows for styling/theme-ing, and seems more descriptive and semantic to me.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
- [ ] Added Feature/Fix to release notes
