### PR TITLE
Remove vue from externals list

### DIFF
--- a/src/components/DropDownItems.vue
+++ b/src/components/DropDownItems.vue
@@ -19,7 +19,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script>
 import { href } from '../href'
 import Vue from 'vue'
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,6 @@
 module.exports = {
   chainWebpack: config => {
     config.externals({
-      'vue': 'Vue',
       'jquery': 'jQuery',
       'bootstrap': 'bootstrap',
       'popper.js': 'Popper.js'


### PR DESCRIPTION
Remove vue from externals list ( this is already done, if run in 'lib…' mode)

Run DropDownItems in js ( not ts) mode as ts mode has issues for .vue files

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
- [ ] Added Feature/Fix to release notes
