### PR TITLE
fix: ci build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,7 @@ pipeline {
             steps {
                 milestone 2
                 container('node') {
+                    sh "npm config set unsafe-perm true"
                     sh "npx semantic-release"
                 }
             }


### PR DESCRIPTION
Set npm configunsafe-perm to true to allow CI root user to npm build/release.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Added Feature/Fix to release notes
